### PR TITLE
fix: Remove image imports to prevent build failure

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,9 +20,12 @@ import {
 import './App.css';
 
 // Import assets
-import logoImage from './assets/tim_harmar_logo_updated.png';
-import heroBackground from './assets/hero_background.png';
-import cybersecurityIcon from './assets/services_cybersecurity.png';
+// import logoImage from './assets/tim_harmar_logo_updated.png';
+// import heroBackground from './assets/hero_background.png';
+// import cybersecurityIcon from './assets/services_cybersecurity.png';
+const logoImage = '/assets/tim_harmar_logo_updated.png';
+const heroBackground = '/assets/hero_background.png';
+
 
 const App = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);


### PR DESCRIPTION
This commit removes the direct import of images in `App.jsx` to prevent the build from failing due to missing assets. The image `src` attributes are replaced with string paths that will work once you add the assets to the `public/assets` directory.